### PR TITLE
Error running command from another project using `pipenv run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,5 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Fixed that links from wrong domains were being updated.
   [#4](https://github.com/hyphacoop/spreadsheet2shortlinks/issues/4)
+- Fixed incorrect install instructions.
+  [#6](https://github.com/hyphacoop/spreadsheet2shortlinks/issues/6)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ for better isolation of Python projects.
 
 ```
 # To use `pipenv` and an isolated project environment via `pipenv run`:
-$ pipenv install git+https://github.com/hyphacoop/spreadsheet2shortlinks#egg=spreadsheet2shortlinks
+$ pipenv install --editable git+https://github.com/hyphacoop/spreadsheet2shortlinks#egg=spreadsheet2shortlinks
 $ pipenv run anki-meetup-memorizer --help
 
 # You can set config via a dot-env file


### PR DESCRIPTION
```
$ pipenv run spreadsheet2shortlinks --gsheet "https://docs.google.com/spreadsheets/d/1DpnzCpXWgQr66nFJFIlpa5XSBrt8IfZaLVZH0_q6kcA/edit#gid=0" --domain-name "link.hypha.club" --verbose --yes
Loading .env environment variables…
Traceback (most recent call last):
  File "/Users/patcon/.virtualenvs/worker-coop-scripts-EG-aJnUH/bin/spreadsheet2shortlinks", line 6, in <module>
    from spreadsheet2shortlinks.cli import gsheet2rebrandly
ModuleNotFoundError: No module named 'spreadsheet2shortlinks'
```